### PR TITLE
删除中暑在teacon

### DIFF
--- a/jiachen/config/eclipticseasons-common.toml
+++ b/jiachen/config/eclipticseasons-common.toml
@@ -2,7 +2,7 @@
 	#Ice or snow layer will melt in warm place..
 	IceAndSnowMelt = false
 	#Add heat stroke effect in summer noon while in hot biome.
-	HeatStroke = true
+	HeatStroke = false
 
 [Season]
 	#The lasting days of each term (24 in total).


### PR DESCRIPTION
**版权声明：我同意在我的 Pull Request 合并成功后，Pull Request 中的内容视作进入公有领域（Public Domain）。**

<!-- 如果有其他需要补充的可以写在这里 -->

忘记把中暑效果删了，这个效果会在夏季轻微模糊玩家屏幕
