### PR TITLE
Configure Beecrasy & Caupona

### DIFF
--- a/2026/config/beecrasy-server.toml
+++ b/2026/config/beecrasy-server.toml
@@ -1,0 +1,45 @@
+[beehive]
+	#Lifespan for an average lifespan gene.
+	# Default: 12000
+	# Range: > 20
+	averageLifespan = 6000
+	#Work interval for a hive.
+	# Default: 100
+	# Range: > 20
+	hiveInterval = 50
+	#Working radius for a hive.
+	# Default: 3
+	# Range: > 1
+	hiveWorkingRadius = 3
+	#Flower transformation radius for a hive.
+	# Default: 4
+	# Range: > 1
+	hiveFloringRadius = 4
+	#Flower transformation try time for a hive.
+	# Default: 1.0
+	# Range: 0.0 ~ 2.147483647E9
+	hiveFloringRate = 0.0
+
+[bees]
+	#Larva dies when leaving hive for specific seconds(20 ticks), set 0 to disable.
+	# Default: 600
+	# Range: > 0
+	larvaSurviveSeconds = 600
+	#Total chance for mutations.
+	# Default: 0.075
+	# Range: 0.0 ~ 1.0
+	mutationChance = 0.15
+
+[sequencer]
+	#Honey consumption in mB.
+	# Default: 25
+	# Range: > 0
+	honeyCost = 25
+	#Energy consumption in FE.
+	# Default: 5000
+	# Range: > 0
+	energyCost = 5000
+	#Energy input limit in FE.
+	# Default: 640
+	# Range: > 0
+	energyLimit = 640

--- a/2026/config/caupona-common.toml
+++ b/2026/config/caupona-common.toml
@@ -12,7 +12,7 @@
 	#Additional speed added per tick for roads
 	# Default: 2.0
 	# Range: 0.0 ~ 10.0
-	roadSpeedAddtion = 0.225
+	roadSpeedAddtion = 0.4
 
 [misc]
 	#Compress output from codecs when sending by network to improve performance.


### PR DESCRIPTION
- [x] **版权声明：我同意在我的 Pull Request 合并成功后，Pull Request 中的内容视作进入公有领域（Public Domain）。**

<!-- 如果有其他需要补充的可以写在这里 -->

* 禁止了 Beecrasy 蜜蜂转化高草的行为；
* 因为 Convivium 展馆预期不使用 Caupona 道路，略微上调了道路的加速幅度，使其更适合潜在的长距离移动需求。